### PR TITLE
example server.py is broken

### DIFF
--- a/examples/server.py
+++ b/examples/server.py
@@ -23,7 +23,7 @@ def application(request):
     dispatcher["add"] = lambda a, b: a + b
 
     response = JSONRPCResponseManager.handle(
-        request.data, dispatcher)
+        request.get_data(cache=False, as_text=True), dispatcher)
     return Response(response.json, mimetype='application/json')
 
 


### PR DESCRIPTION
Using python 3.3 on Ubuntu 13.10. server.py doesn't work out of the box. The fix is simple: basically use werkzeug's request.get_data to massage the request data bytestring into a unicode string, and pass that in instead.
