### PR TITLE
allow logging of exceptions in API handlers to screen/file

### DIFF
--- a/jsonrpc/manager.py
+++ b/jsonrpc/manager.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from .exceptions import (
     JSONRPCInvalidParams,
     JSONRPCInvalidRequest,
@@ -93,6 +94,8 @@ class JSONRPCResponseManager(object):
                 yield response(error=JSONRPCInvalidParams()._data)
                 continue
             except Exception as e:
+                logger = logging.getLogger("jsonrpc")
+                logger.exception("API Exception")
                 data = {
                     "type": e.__class__.__name__,
                     "args": e.args,


### PR DESCRIPTION
with this patch, exceptions are logged to screen/file with the logging module (this allows the developer to see the back trace in the logs for exceptions triggered within his API handler code). Because we log via the "jsonrpc"logger, the user can suppress this logging if they so wish
