### PR TITLE
allow None to be returned in JSON API handlers

### DIFF
--- a/jsonrpc/base.py
+++ b/jsonrpc/base.py
@@ -58,9 +58,6 @@ class JSONRPCBaseResponse(JSONSerializable):
         self.error = error
         self._id = _id
 
-        if self.result is None and self.error is None:
-            raise ValueError("Either result or error should be used")
-
     @property
     def data(self):
         return self._data


### PR DESCRIPTION
I have several API handlers where I'd like to return None if no data is returned. with the code I'm proposing removing present, it would cause an error, and require hackish solutions such as returning False, [], {} etc instead.
