### PR TITLE
Don't destroy callable with dispatcher decorator.

### DIFF
--- a/jsonrpc/dispatcher.py
+++ b/jsonrpc/dispatcher.py
@@ -36,6 +36,9 @@ class Dispatcher(collections.MutableMapping):
     def __iter__(self):
         return iter(self.method_map)
 
+    def __repr__(self):
+        return repr(self.method_map)
+
     def add_method(self, f, name=None):
         """ Add a method to the dispatcher.
 

--- a/jsonrpc/tests/test_dispatcher.py
+++ b/jsonrpc/tests/test_dispatcher.py
@@ -83,3 +83,8 @@ class TestDispatcher(unittest.TestCase):
 
         self.assertIn("one", d)
         self.assertIn("two", d)
+
+    def test_dispatcher_representation(self):
+
+        d = Dispatcher()
+        self.assertEqual('{}', repr(d))


### PR DESCRIPTION
There was a little problem with dispatcher

``` python
In [1]: from jsonrpc import dispatcher

In [2]: @dispatcher.add_method
   ...: def a(*args):
   ...:     return sum(args)
   ...: 

In [3]: print(a)
None
```
