### PR TITLE
Added support of method prefixes

### DIFF
--- a/jsonrpc/dispatcher.py
+++ b/jsonrpc/dispatcher.py
@@ -50,6 +50,19 @@ class Dispatcher(collections.MutableMapping):
     def __repr__(self):
         return repr(self.method_map)
 
+    def add_class(self, cls):
+        prefix = cls.__name__.lower()+'.'
+        self.build_method_map(cls(), prefix)
+
+    def add_object(self, obj):
+        prefix = obj.__class__.__name__.lower()+'.'
+        self.build_method_map(obj, prefix)
+
+    def add_dict(self, dict, prefix=''):
+        if prefix:
+            prefix += '.'
+        self.build_method_map(dict, prefix)
+
     def add_method(self, f, name=None):
         """ Add a method to the dispatcher.
 
@@ -84,7 +97,7 @@ class Dispatcher(collections.MutableMapping):
         self.method_map[name or f.__name__] = f
         return f
 
-    def build_method_map(self, prototype):
+    def build_method_map(self, prototype, prefix=''):
         """ Add prototype methods to the dispatcher.
 
         Parameters
@@ -95,6 +108,8 @@ class Dispatcher(collections.MutableMapping):
             be added to dispatcher.
             If given prototype is an object then all public methods will
             be used.
+        prefix: string, optional
+            Prefix of methods
 
         """
         if not isinstance(prototype, dict):
@@ -104,4 +119,4 @@ class Dispatcher(collections.MutableMapping):
 
         for attr, method in prototype.items():
             if callable(method):
-                self[attr] = method
+                self[prefix+attr] = method

--- a/jsonrpc/tests/test_dispatcher.py
+++ b/jsonrpc/tests/test_dispatcher.py
@@ -6,6 +6,15 @@ else:
     import unittest
 
 
+class Math:
+
+    def sum(self, a, b):
+        return a+b
+
+    def diff(self, a, b):
+        return a-b
+
+
 class TestDispatcher(unittest.TestCase):
 
     """ Test Dispatcher functionality."""
@@ -33,6 +42,31 @@ class TestDispatcher(unittest.TestCase):
 
         self.assertIn("add", d)
         self.assertEqual(d["add"](1, 1), 2)
+
+    def test_add_class(self):
+        d = Dispatcher()
+        d.add_class(Math)
+
+        self.assertIn("math.sum", d)
+        self.assertIn("math.diff", d)
+        self.assertEqual(d["math.sum"](3, 8), 11)
+        self.assertEqual(d["math.diff"](6, 9), -3)
+
+    def test_add_object(self):
+        d = Dispatcher()
+        d.add_object(Math())
+
+        self.assertIn("math.sum", d)
+        self.assertIn("math.diff", d)
+        self.assertEqual(d["math.sum"](5, 2), 7)
+        self.assertEqual(d["math.diff"](15, 9), 6)
+
+    def test_add_dict(self):
+        d = Dispatcher()
+        d.add_dict({"sum": lambda *args: sum(args)}, "util")
+
+        self.assertIn("util.sum", d)
+        self.assertEqual(d["util.sum"](13, -2), 11)
 
     def test_add_method_keep_function_definitions(self):
 


### PR DESCRIPTION
Using prefixed methods is very comfortably for group methods by Models.
For example: instead of methods: get_user_info, get_partner_info, get_user_money, get_partner_money, send_message_to_user, send_message_to_partner
you can use: user.get_info, partner.get_info, user.get_money, partner.get_money, partner.send_message, user.send_message
with using two classes User and Partner

With methods dispatcher.add_class, dispatcher.add_object you can automaticaly load all models in folder (with importlib.import_module for example)


```python
class Math:

    def sum(self, a, b):
        return a+b

    def diff(self, a, b):
        return a-b

dispatcher.add_class(Math)

dispatcher["math.sum"](12,4)
```

>16
