### PR TITLE
Skip django/flask tests if not installed

### DIFF
--- a/jsonrpc/tests/test_backend_django/tests.py
+++ b/jsonrpc/tests/test_backend_django/tests.py
@@ -2,8 +2,13 @@
 from __future__ import absolute_import
 import os
 
-from django.core.urlresolvers import RegexURLPattern
-from django.test import TestCase
+try:
+    from django.core.urlresolvers import RegexURLPattern
+    from django.test import TestCase
+except ImportError:
+    import unittest
+    raise unittest.SkipTest('Django not found for testing')
+
 from ...backend.django import JSONRPCAPI, api
 import json
 

--- a/jsonrpc/tests/test_backend_flask/tests.py
+++ b/jsonrpc/tests/test_backend_flask/tests.py
@@ -7,9 +7,13 @@ if sys.version_info < (2, 7):
 else:
     import unittest
 
-# Flask is supported only for python2 and pyton3.3+
+# Flask is supported only for python2 and python3.3+
 if sys.version_info < (3, 0) or sys.version_info >= (3, 3):
-    from flask import Flask
+    try:
+        from flask import Flask
+    except ImportError:
+        raise unittest.SkipTest('Flask not found for testing')
+
     from ...backend.flask import JSONRPCAPI, api
 
     @api.dispatcher.add_method


### PR DESCRIPTION
- Django and Flask are not firm requirements set out in the setup.py so makes
  sense to not mark the tests as failed if they aren't installed.