### PR TITLE
Log exception in RPC function regardless of exception type

### DIFF
--- a/jsonrpc/manager.py
+++ b/jsonrpc/manager.py
@@ -109,6 +109,8 @@ class JSONRPCResponseManager(object):
                 except JSONRPCDispatchException as e:
                     output = response(error=e.error._data)
                 except Exception as e:
+                    logger.exception("API Exception:")
+
                     data = {
                         "type": e.__class__.__name__,
                         "args": e.args,
@@ -119,7 +121,6 @@ class JSONRPCResponseManager(object):
                         output = response(
                             error=JSONRPCInvalidParams(data=data)._data)
                     else:
-                        logger.exception("API Exception: {0}".format(data))
                         output = response(
                             error=JSONRPCServerError(data=data)._data)
                 else:

--- a/jsonrpc/manager.py
+++ b/jsonrpc/manager.py
@@ -109,13 +109,14 @@ class JSONRPCResponseManager(object):
                 except JSONRPCDispatchException as e:
                     output = response(error=e.error._data)
                 except Exception as e:
-                    logger.exception("API Exception:")
-
                     data = {
                         "type": e.__class__.__name__,
                         "args": e.args,
                         "message": str(e),
                     }
+
+                    logger.exception("API Exception: {0}".format(data))
+
                     if isinstance(e, TypeError) and is_invalid_params(
                             method, *request.args, **request.kwargs):
                         output = response(


### PR DESCRIPTION
It's useful as a server-side developer to see the stack trace regardless if the error is a TypeError or not.