### PR TITLE
Fix Flask example

### DIFF
--- a/docs/source/flask_integration.rst
+++ b/docs/source/flask_integration.rst
@@ -48,7 +48,7 @@ Second - register as a usual view.
     from jsonrpc.backend.flask import api
 
     app = Flask(__name__)
-    app.add_url_rule('/', 'api', api.as_view())
+    app.add_url_rule('/', 'api', api.as_view(), methods=['POST'])
 
 
 Add methods to api


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.
* If pull request breaks tests it would not be merged.

### Description of the Change

Working Flask example. By default Flask allows GET only. This fix is required to make it work as expected.

### Alternate Designs

Nothing

### Benefits

Accurate documentation

### Possible Drawbacks

I don't think there is, since having JSON RPC on GET does not make sense.

### Applicable Issues

Nope
