### PR TITLE
Removed logging in backend.flask because it assumed jsonrpc_request c…

### DIFF
--- a/jsonrpc/backend/flask.py
+++ b/jsonrpc/backend/flask.py
@@ -51,14 +51,8 @@ class JSONRPCAPI(object):
             response = JSONRPCResponseManager.handle(
                 request_str, self.dispatcher)
         else:
-            jsonrpc_request.params = jsonrpc_request.params or {}
-            jsonrpc_request_params = copy.copy(jsonrpc_request.params)
-            t1 = time.time()
             response = JSONRPCResponseManager.handle_request(
                 jsonrpc_request, self.dispatcher)
-            t2 = time.time()
-            logger.info('{0}({1}) {2:.2f} sec'.format(
-                jsonrpc_request.method, jsonrpc_request_params, t2 - t1))
 
         if response:
             response.serialize = self._serialize


### PR DESCRIPTION
…ould only be of type JSONRPCRequest when it actually could also be JSONRPCBatchRequest which does not have a params according the the json rpc spec.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions.
* If pull request breaks tests it would not be merged.

### Description of the Change

The logging code in the flask backend assumes that jsonrpc_request is JSONRPCRequest with a params attribute. This will causes batch requests in Flask to fail. Removing this code should fix the issue with no adverse effects.

### Alternate Designs

We could move the logging into handle_request.

### Benefits

Expected behavior that matches the jsonrpc spec.

### Possible Drawbacks

No more logger statement telling you how long the code took to execute.

### Applicable Issues

<!-- Enter any applicable Issues (Bugs, Feature Requests) here -->
