### PR TITLE
add ability to override name with decorator convention

### DIFF
--- a/jsonrpc/dispatcher.py
+++ b/jsonrpc/dispatcher.py
@@ -3,6 +3,7 @@
 For usage examples see :meth:`Dispatcher.add_method`
 
 """
+import functools
 import collections
 
 
@@ -63,7 +64,7 @@ class Dispatcher(collections.MutableMapping):
             prefix += '.'
         self.build_method_map(dict, prefix)
 
-    def add_method(self, f, name=None):
+    def add_method(self, f=None, name=None):
         """ Add a method to the dispatcher.
 
         Parameters
@@ -93,7 +94,16 @@ class Dispatcher(collections.MutableMapping):
             def mymethod(*args, **kwargs):
                 print(args, kwargs)
 
+        Or use as a decorator with a different function name
+        >>> d = Dispatcher()
+        >>> @d.add_method(name="my.method")
+            def mymethod(*args, **kwargs):
+                print(args, kwargs)
+
         """
+        if name and not f:
+            return functools.partial(self.add_method, name=name)
+
         self.method_map[name or f.__name__] = f
         return f
 

--- a/jsonrpc/tests/test_dispatcher.py
+++ b/jsonrpc/tests/test_dispatcher.py
@@ -43,6 +43,17 @@ class TestDispatcher(unittest.TestCase):
         self.assertIn("add", d)
         self.assertEqual(d["add"](1, 1), 2)
 
+    def test_add_method_with_name(self):
+        d = Dispatcher()
+
+        @d.add_method(name="this.add")
+        def add(x, y):
+            return x + y
+
+        self.assertNotIn("add", d)
+        self.assertIn("this.add", d)
+        self.assertEqual(d["this.add"](1, 1), 2)
+
     def test_add_class(self):
         d = Dispatcher()
         d.add_class(Math)


### PR DESCRIPTION
### Description of the Change

Currently, there is no way to override the method name when using the
decorator convention. A small change adds the ability to do so.

With this change, the following become possible.

```
@d.add_method
    def one(x):
        return x

@d.add_method()  # no longer an issue
    def one(x):
        return x

@d.add_method(name="not.really.x")
    def one(x):
        return x
```

### Alternate Designs

It is possible to subclass Dispatcher in users codebase, and utilize that as the dispatcher, but it would be nicer to have this upstream (less code required)

### Benefits

The ability to override the name used for method lookup. This can be helpful if code in two separate files happens to have the same name, or if you wish to expose a different name (to make api versioning easier).

### Possible Drawbacks

Additional complexity of `add_method` function. `functools.partial` should be available back to python 2.5, so compatibility /shouldn't/ be an issue. There is a small runtime cost, but only at parse time, not run time.

### Applicable Issues

None.