### PR TITLE
Asyncio json rpc manager

### DIFF
--- a/examples/asyncserver.py
+++ b/examples/asyncserver.py
@@ -1,0 +1,40 @@
+""" Example of json-rpc usage with asyncio and raw tcp server.
+"""
+
+import asyncio
+from jsonrpc import AsyncJSONRPCResponseManager,dispatcher
+
+
+@dispatcher.add_method
+def foobar(**kwargs):
+    return kwargs["foo"] + kwargs["bar"]
+
+
+async def process_request(request_data, client_writer): 
+    response = await AsyncJSONRPCResponseManager.handle(request_data, dispatcher)
+    client_writer.write(response.json.encode())
+    client_writer.write("\r\n".encode())
+
+def accept_client(client_reader, client_writer):
+    task = asyncio.Task(handle_client(client_reader, client_writer))
+
+async def handle_client(client_reader, client_writer):
+    tasks = {}
+
+    while True:
+        data = await asyncio.wait_for(client_reader.readline(), timeout=60.0)
+        if len(data)==0 or data is None:
+            break
+        asyncio.Task(process_request(data.decode(), client_writer))
+
+    client_writer.close()
+
+
+if __name__ == '__main__':
+    import signal
+    signal.signal(signal.SIGINT, signal.SIG_DFL) #to make ctrl+c work on windows
+
+    loop = asyncio.get_event_loop()
+    f = asyncio.start_server(accept_client, host=None, port=4000)
+    loop.run_until_complete(f)
+    loop.run_forever()

--- a/jsonrpc/__init__.py
+++ b/jsonrpc/__init__.py
@@ -1,4 +1,5 @@
 from .manager import JSONRPCResponseManager
+from .asyncmanager import AsyncJSONRPCResponseManager
 from .dispatcher import Dispatcher
 
 __version = (1, 10, 8)

--- a/jsonrpc/asyncmanager.py
+++ b/jsonrpc/asyncmanager.py
@@ -1,0 +1,142 @@
+import json
+import logging
+import asyncio
+from .utils import is_invalid_params
+from .exceptions import (
+    JSONRPCInvalidParams,
+    JSONRPCInvalidRequest,
+    JSONRPCInvalidRequestException,
+    JSONRPCMethodNotFound,
+    JSONRPCParseError,
+    JSONRPCServerError,
+    JSONRPCDispatchException,
+)
+from .jsonrpc1 import JSONRPC10Response
+from .jsonrpc2 import (
+    JSONRPC20BatchRequest,
+    JSONRPC20BatchResponse,
+    JSONRPC20Response,
+)
+from .jsonrpc import JSONRPCRequest
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncJSONRPCResponseManager(object):
+
+    """ JSON-RPC response manager.
+
+    Method brings syntactic sugar into library. Given dispatcher it handles
+    request (both single and batch) and handles errors.
+    Request could be handled in parallel, it is server responsibility.
+
+    :param str request_str: json string. Will be converted into
+        JSONRPC20Request, JSONRPC20BatchRequest or JSONRPC10Request
+
+    :param dict dispather: dict<function_name:function>.
+
+    """
+
+    RESPONSE_CLASS_MAP = {
+        "1.0": JSONRPC10Response,
+        "2.0": JSONRPC20Response,
+    }
+
+    @classmethod
+    async def handle(cls, request_str, dispatcher):
+        if isinstance(request_str, bytes):
+            request_str = request_str.decode("utf-8")
+
+        try:
+            data = json.loads(request_str)
+        except (TypeError, ValueError):
+            return JSONRPC20Response(error=JSONRPCParseError()._data)
+
+        try:
+            request = JSONRPCRequest.from_data(data)
+        except JSONRPCInvalidRequestException:
+            return JSONRPC20Response(error=JSONRPCInvalidRequest()._data)
+
+        return await cls.handle_request(request, dispatcher)
+
+    @classmethod
+    async def handle_request(cls, request, dispatcher):
+        """ Handle request data.
+
+        At this moment request has correct jsonrpc format.
+
+        :param dict request: data parsed from request_str.
+        :param jsonrpc.dispatcher.Dispatcher dispatcher:
+
+        .. versionadded: 1.8.0
+
+        """
+        rs = request if isinstance(request, JSONRPC20BatchRequest) \
+            else [request]
+        responses = [r for r in (await cls._get_responses(rs, dispatcher))
+                     if r is not None]
+
+        # notifications
+        if not responses:
+            return
+
+        if isinstance(request, JSONRPC20BatchRequest):
+            response = JSONRPC20BatchResponse(*responses)
+            response.request = request
+            return response
+        else:
+            return responses[0]
+
+    @classmethod
+    async def _get_responses(cls, requests, dispatcher):
+        """ Response to each single JSON-RPC Request.
+
+        :return iterator(JSONRPC20Response):
+
+        .. versionadded: 1.9.0
+          TypeError inside the function is distinguished from Invalid Params.
+
+        """
+        results = []
+        for request in requests:
+            def make_response(**kwargs):
+                response = cls.RESPONSE_CLASS_MAP[request.JSONRPC_VERSION](
+                    _id=request._id, **kwargs)
+                response.request = request
+                return response
+
+            try:
+                method = dispatcher[request.method]
+            except KeyError:
+                output = make_response(error=JSONRPCMethodNotFound()._data)
+            else:
+                try:
+                    if asyncio.iscoroutinefunction(method):
+                        result = await method(*request.args, **request.kwargs)
+                    else:
+                        result = method(*request.args, **request.kwargs)
+                except JSONRPCDispatchException as e:
+                    output = make_response(error=e.error._data)
+                except Exception as e:
+                    data = {
+                        "type": e.__class__.__name__,
+                        "args": e.args,
+                        "message": str(e),
+                    }
+
+                    logger.exception("API Exception: {0}".format(data))
+
+                    if isinstance(e, TypeError) and is_invalid_params(
+                            method, *request.args, **request.kwargs):
+                        output = make_response(
+                            error=JSONRPCInvalidParams(data=data)._data)
+                    else:
+                        output = make_response(
+                            error=JSONRPCServerError(data=data)._data)
+                else:
+                    output = make_response(result=result)
+            finally:
+                if not request.is_notification:
+                    results.append(output)
+
+        return results

--- a/jsonrpc/jsonrpc1.py
+++ b/jsonrpc/jsonrpc1.py
@@ -93,7 +93,7 @@ class JSONRPC10Request(JSONRPCBaseRequest):
 
         if cls.REQUIRED_FIELDS <= set(data.keys()) <= cls.POSSIBLE_FIELDS:
             return cls(
-                method=data["method"], params=data["params"], _id=data["id"]
+                method=data["method"], params=data["params"][0], _id=data["id"]
             )
         else:
             extra = set(data.keys()) - cls.POSSIBLE_FIELDS

--- a/jsonrpc/jsonrpc2.py
+++ b/jsonrpc/jsonrpc2.py
@@ -4,7 +4,6 @@ import json
 from .exceptions import JSONRPCError, JSONRPCInvalidRequestException
 from .base import JSONRPCBaseRequest, JSONRPCBaseResponse
 
-
 class JSONRPC20Request(JSONRPCBaseRequest):
 
     """ A rpc call is represented by sending a Request object to a Server.
@@ -133,7 +132,7 @@ class JSONRPC20Request(JSONRPCBaseRequest):
 
             try:
                 result.append(JSONRPC20Request(
-                    method=d["method"], params=d.get("params"),
+                    method=d["method"], params=d.get("params")[0],
                     _id=d.get("id"), is_notification="id" not in d,
                 ))
             except ValueError as e:


### PR DESCRIPTION
### Requirements

* Make it possible to create raw tcp async server with json-rpc

### Description of the Change

* AsyncJSONRPCResponseManager, which is async-version of JSONRPCResponseManager

### Alternate Designs

* ?

### Benefits

* It allows for request batching - you pause after first request to see if any other requests will arrive, and then process them all in one batch. It's useful to server ML models - see batching at https://github.com/tensorflow/serving/blob/master/tensorflow_serving/g3doc/serving_advanced.md

### Possible Drawbacks

* AsyncJSONRPCResponseManager is a lot of copy-paste
* I have not tested JSONRPC20BatchRequest, whether its subrequests are process synchrounously or not.
* I thought using async-version would be slower, but my measurement showed that's insignificant, in terms of throughput at least (i did not measure latency)

### Applicable Issues

* #30 - https://github.com/pavlov99/json-rpc/issues/30
