### PR TITLE
Fix urls.py instructions in Django integration docs.

### DIFF
--- a/docs/source/django_integration.rst
+++ b/docs/source/django_integration.rst
@@ -33,7 +33,7 @@ In your urls.py file add
 
     urlpatterns = patterns(
         ...
-        url(r'^api/jsonrpc$', include(api.urls)),
+        url(r'^api/jsonrpc/', include(api.urls)),
     )
 
 Add methods to api


### PR DESCRIPTION
This patch fixes a typo in the docs for integrating with Django.

The current instructions, for example, trigger the following Django warning:
https://github.com/django/django/blob/fe3fc5210f0bb334a679ed420152af1c862c0239/django/core/checks/urls.py#L49
