### PR TITLE
Allow to change the serialization and deserialization methods used by the library

### DIFF
--- a/jsonrpc/jsonrpc2.py
+++ b/jsonrpc/jsonrpc2.py
@@ -1,8 +1,8 @@
 ﻿from . import six
-import json
 
 from .exceptions import JSONRPCError, JSONRPCInvalidRequestException
 from .base import JSONRPCBaseRequest, JSONRPCBaseResponse
+from .utils import JSONSerializable
 
 
 class JSONRPC20Request(JSONRPCBaseRequest):
@@ -142,7 +142,7 @@ class JSONRPC20Request(JSONRPCBaseRequest):
         return JSONRPC20BatchRequest(*result) if is_batch else result[0]
 
 
-class JSONRPC20BatchRequest(object):
+class JSONRPC20BatchRequest(JSONSerializable):
 
     """ Batch JSON-RPC 2.0 Request.
 
@@ -161,7 +161,7 @@ class JSONRPC20BatchRequest(object):
 
     @property
     def json(self):
-        return json.dumps([r.data for r in self.requests])
+        return self.serialize([r.data for r in self.requests])
 
     def __iter__(self):
         return iter(self.requests)
@@ -247,7 +247,7 @@ class JSONRPC20Response(JSONRPCBaseResponse):
         self._data["id"] = value
 
 
-class JSONRPC20BatchResponse(object):
+class JSONRPC20BatchResponse(JSONSerializable):
 
     JSONRPC_VERSION = "2.0"
 
@@ -261,7 +261,7 @@ class JSONRPC20BatchResponse(object):
 
     @property
     def json(self):
-        return json.dumps(self.data)
+        return self.serialize(self.data)
 
     def __iter__(self):
         return iter(self.responses)

--- a/jsonrpc/manager.py
+++ b/jsonrpc/manager.py
@@ -41,13 +41,19 @@ class JSONRPCResponseManager(object):
         "2.0": JSONRPC20Response,
     }
 
+    deserialize = staticmethod(json.loads)
+
+    @staticmethod
+    def validate(request_str):
+        if isinstance(request_str, bytes):
+            return request_str.decode("utf-8")
+        else:
+            return request_str
+
     @classmethod
     def handle(cls, request_str, dispatcher):
-        if isinstance(request_str, bytes):
-            request_str = request_str.decode("utf-8")
-
         try:
-            data = json.loads(request_str)
+            data = cls.deserialize(cls.validate(request_str))
         except (TypeError, ValueError):
             return JSONRPC20Response(error=JSONRPCParseError()._data)
 


### PR DESCRIPTION
### Description of the Change

Subclass JSONSerializable from JSONRPC20BatchRequest and JSONRPC20BatchResponse to allow usage of JSONSerializable's methods `serialize` and `deserialize`.

Decouple request validation from JSONRPCResponseManager's `handle` method and introduce a static method inside JSONRPCResponseManager named `deserialize` (analogous to JSONSerializable).

### Benefits

These changes allow to change the serialization and deserialization methods used by the library without overwriting its logic. (e.g. use `cbor2.loads` / `cbor2.dumps` instead of `json.loads` / `json.dumps`)