### PR TITLE
misc updates

### DIFF
--- a/jsonrpc/backend/flask.py
+++ b/jsonrpc/backend/flask.py
@@ -19,7 +19,8 @@ logger = logging.getLogger(__name__)
 
 
 class JSONRPCAPI(object):
-    def __init__(self, dispatcher=None, check_content_type=True):
+    def __init__(self, dispatcher=None, check_content_type=True,
+                 json_encoder=None):
         """
 
         :param dispatcher: methods dispatcher
@@ -31,6 +32,7 @@ class JSONRPCAPI(object):
         self.dispatcher = dispatcher if dispatcher is not None \
             else Dispatcher()
         self.check_content_type = check_content_type
+        self.json_encoder = json_encoder or DatetimeDecimalEncoder
 
     def as_blueprint(self, name=None):
         blueprint = Blueprint(name if name else str(uuid4()), __name__)
@@ -83,9 +85,9 @@ class JSONRPCAPI(object):
             return request.data
         return list(request.form.keys())[0]
 
-    @staticmethod
-    def _serialize(s):
-        return json.dumps(s, cls=DatetimeDecimalEncoder)
+    # @staticmethod
+    def _serialize(self, s):
+        return json.dumps(s, cls=self.json_encoder)
 
 
 api = JSONRPCAPI()

--- a/jsonrpc/tests/test_dispatcher.py
+++ b/jsonrpc/tests/test_dispatcher.py
@@ -90,10 +90,10 @@ class TestDispatcher(unittest.TestCase):
         d = Dispatcher()
 
         def func():
-            return ""
+            return "x"
 
         d["method"] = func
-        self.assertEqual(dict(d), {"method": func})
+        self.assertEqual(dict(d)["method"](), "x")
 
     def test_init_from_object_instance(self):
 


### PR DESCRIPTION
Some misc updates when I apply json-rpc to latest two projects. Just for your review.

- Support custom json encoder for serializing response data
- Support registering global decorators for jsonrpc methods
- Support custom method prefix for Dispatcher.add_class
- Support explicitly exporting subset of class methods with Dispatcher.add_class

```
$ tox -e py27,py35,py36 
  py27: commands succeeded
  py35: commands succeeded
  py36: commands succeeded
  congratulations :)
```

---

### Some use cases from my real projects

```python
from awesome.json import JSONEncoder
jsonrpc_api = JSONRPCAPI(json_encoder=JSONEncoder)
```

```python
from awesome.auth.decorators import login_required
dispatcher.register_decorator(login_required)
````

```python
@dispatcher.add_class
class CellAPI(APISet):
    rpc_exports = ['detail', 'create', 'update']
    rpc_method_prefix = 'Cell'
    ### ...
```