### PR TITLE
REF: function parameter introspection

### DIFF
--- a/jsonrpc/tests/test_utils.py
+++ b/jsonrpc/tests/test_utils.py
@@ -120,3 +120,11 @@ class TestUtils(unittest.TestCase):
         self.assertFalse(is_invalid_params(lambda a, b: None, 0, **{"b": 1}))
         self.assertFalse(is_invalid_params(
             lambda a, b, c=0: None, 0, **{"b": 1}))
+
+    def test_is_invalid_params_py2(self):
+        with patch('jsonrpc.utils.sys') as mock_sys:
+            mock_sys.version_info = (2, 7)
+            with patch('jsonrpc.utils.is_invalid_params_py2') as mock_func:
+                is_invalid_params(lambda a: None, 0)
+
+        assert mock_func.call_count == 1

--- a/jsonrpc/tests/test_utils.py
+++ b/jsonrpc/tests/test_utils.py
@@ -98,18 +98,25 @@ class TestUtils(unittest.TestCase):
 
     def test_is_invalid_params_builtin(self):
         self.assertTrue(is_invalid_params(sum, 0, 0))
-        # NOTE: Function generates TypeError already
-        # self.assertFalse(is_invalid_params(sum, [0, 0]))
+        # NOTE: builtin functions could not be recognized by inspect.isfunction
+        # It would raise TypeError if parameters are incorrect already.
+        # self.assertFalse(is_invalid_params(sum, [0, 0]))  # <- fails
 
     def test_is_invalid_params_args(self):
         self.assertTrue(is_invalid_params(lambda a, b: None, 0))
         self.assertTrue(is_invalid_params(lambda a, b: None, 0, 1, 2))
 
     def test_is_invalid_params_kwargs(self):
-        self.assertTrue(is_invalid_params(lambda x: None, **{}))
-        self.assertTrue(is_invalid_params(lambda x: None, **{"x": 0, "y": 1}))
+        self.assertTrue(is_invalid_params(lambda a: None, **{}))
+        self.assertTrue(is_invalid_params(lambda a: None, **{"a": 0, "b": 1}))
 
     def test_invalid_params_correct(self):
-        # self.assertFalse(is_invalid_params(lambda: None))
+        self.assertFalse(is_invalid_params(lambda: None))
         self.assertFalse(is_invalid_params(lambda a: None, 0))
         self.assertFalse(is_invalid_params(lambda a, b=0: None, 0))
+        self.assertFalse(is_invalid_params(lambda a, b=0: None, 0, 0))
+
+    def test_is_invalid_params_mixed(self):
+        self.assertFalse(is_invalid_params(lambda a, b: None, 0, **{"b": 1}))
+        self.assertFalse(is_invalid_params(
+            lambda a, b, c=0: None, 0, **{"b": 1}))


### PR DESCRIPTION
### Description of the Change

* Split introspection into python 2 and python 3 specific code;
* Fix introspection for mix of args and kwargs parameters with
default values.
* Fix test warnings in python 3 (as `getarspec` is not preferred)

### Alternate Designs

Use a mix of `getargspec` and `getfullargspec` and try to keep py2 and py3 code similar.

### Benefits

Use modern methods in modern python
Have better control over function parameter introspection via lower level methods

### Possible Drawbacks

N/A

### Applicable Issues

N/A