### PR TITLE
Add py38 support, fix testsuite, and test deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ workflows:
       - py35
       - py36
       - py37
+      - py38
       - pycodestyle
       - cov
 jobs:
@@ -46,6 +47,10 @@ jobs:
     <<: *test-template
     docker:
       - image: circleci/python:3.7
+  py38:
+    <<: *test-template
+    docker:
+      - image: circleci/python:3.8
   pycodestyle:
     <<: *test-template
   cov:

--- a/jsonrpc/dispatcher.py
+++ b/jsonrpc/dispatcher.py
@@ -4,10 +4,13 @@ For usage examples see :meth:`Dispatcher.add_method`
 
 """
 import functools
-import collections
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 
 
-class Dispatcher(collections.MutableMapping):
+class Dispatcher(MutableMapping):
 
     """ Dictionary like object which maps method_name to method."""
 

--- a/jsonrpc/tests/test_manager.py
+++ b/jsonrpc/tests/test_manager.py
@@ -94,6 +94,7 @@ class TestJSONRPCResponseManager(unittest.TestCase):
         self.assertIn(response.error["data"]["message"], [
             'sum() takes no keyword arguments',
             "sum() got an unexpected keyword argument 'a'",
+            'sum() takes at least 1 positional argument (0 given)',
         ])
 
     def test_invalid_params_custom_function(self):

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,12 @@ deps =
     Django==1.11
     Flask==0.12.2
 
+[testenv:py38]
+deps =
+    pytest==5.2.2
+    Django==2.2.7
+    Flask==1.1.1
+
 # Python 2.6 configuration. Latest Django support is 1.6
 [testenv:py26]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, py36, py37, pypy, pypy3, pycodestyle, cov
+envlist = py26, py27, py33, py34, py35, py36, py37, py38, pypy, pypy3, pycodestyle, cov
 
 [testenv]
 commands = pytest


### PR DESCRIPTION
I think json-rpc fails tests with py3.8, something to do with "positional/keyword only args"