### PR TITLE
Add feature that allows adding Dispatcher context to function calls

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,3 +24,4 @@ Laurent Mazuel (@lmazuel) <lmazuel@microsoft.com>
 Igor Melnyk (@liminspace) <igormeln@gmail.com>
 Ghislain Antony Vaillant (@ghisvail) <ghisvail@gmail.com>
 Chris Jerdonek (@cjerdonek) <chris.jerdonek@gmail.com>
+Paulie Peña (@ppena-LiveData) <ppena@livedata.com>

--- a/jsonrpc/manager.py
+++ b/jsonrpc/manager.py
@@ -105,6 +105,7 @@ class JSONRPCResponseManager(object):
 
             output = None
             try:
+                dispatcher.update_context({"id": request._id})
                 method = dispatcher[request.method]
             except KeyError:
                 output = make_response(error=JSONRPCMethodNotFound()._data)

--- a/jsonrpc/tests/test_dispatcher.py
+++ b/jsonrpc/tests/test_dispatcher.py
@@ -54,6 +54,16 @@ class TestDispatcher(unittest.TestCase):
         self.assertIn("this.add", d)
         self.assertEqual(d["this.add"](1, 1), 2)
 
+    def test_add_method_with_context(self):
+        d = Dispatcher()
+
+        @d.add_method(context_arg="context")
+        def x_plus_id(x, context):
+            return x + context["id"]
+
+        d.update_context({"id": 3})
+        self.assertEqual(d["x_plus_id"](2), 5)
+
     def test_add_class(self):
         d = Dispatcher()
         d.add_class(Math)

--- a/jsonrpc/tests/test_dispatcher.py
+++ b/jsonrpc/tests/test_dispatcher.py
@@ -61,8 +61,7 @@ class TestDispatcher(unittest.TestCase):
         def x_plus_id(x, context):
             return x + context["id"]
 
-        d.update_context({"id": 3})
-        self.assertEqual(d["x_plus_id"](2), 5)
+        self.assertEqual(d.context_arg_for_method["x_plus_id"], "context")
 
     def test_add_class(self):
         d = Dispatcher()

--- a/jsonrpc/tests/test_manager.py
+++ b/jsonrpc/tests/test_manager.py
@@ -42,7 +42,7 @@ class TestJSONRPCResponseManager(unittest.TestCase):
 
         @self.dispatcher.add_method(context_arg="context")
         def return_json_rpc_id(context):
-            return context["id"]
+            return context["request"]._id
 
     def test_dispatch_error(self):
         request = JSONRPC20Request("dispatch_error", ["test"], _id=0)
@@ -181,5 +181,6 @@ class TestJSONRPCResponseManager(unittest.TestCase):
 
     def test_setting_json_rpc_id_in_context(self):
         request = JSONRPC20Request("return_json_rpc_id", _id=42)
-        response = JSONRPCResponseManager.handle(request.json, self.dispatcher)
+        response = JSONRPCResponseManager.handle(request.json, self.dispatcher,
+                                                 context={})
         self.assertEqual(response.data["result"], 42)


### PR DESCRIPTION
This fixes #79, and `JSONRPCResponseManager` now automatically adds the JSON-RPC `id` to the Dispatcher context.

### Description of the Change

As #79 pointed out, it would be nice to be able to add context data that can be passed to a JSON-RPC method handler, but since `JSONRPCResponseManager` loops over the JSON-RPC messages and calls the handler for us, the only way to get the `id` of the JSON-RPC message is for `JSONRPCResponseManager` to add the `id` to the context, since the user does not have access to it. This uses a similar approach to what https://pjrpc.readthedocs.io/en/latest/pjrpc/server.html uses, i.e. the context argument name is passed to the decorator.

### Alternate Designs

https://jsonrpcserver.readthedocs.io/en/stable/api.html#context passes the context data as part of the `dispatch()` call, but doing it that way breaks the sugar that `JSONRPCResponseManager` provides to loop over all the JSON-RPC messages for us.

### Benefits

Users can now pass their own context, and users will now have access to the JSON-RPC message `id`.

### Possible Drawbacks

None that I can think of.

### Applicable Issues

#79
